### PR TITLE
Added optional \r into regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 
 module.exports = function extractMetablock (userscriptText) {
   try {
-    var blocksReg = /\B(\/\/ ==UserScript==\n([\S\s]*?)\n\/\/ ==\/UserScript==)([\S\s]*)/
+    var blocksReg = /\B(\/\/ ==UserScript==\r?\n([\S\s]*?)\r?\n\/\/ ==\/UserScript==)([\S\s]*)/
     var blocks = userscriptText.match(blocksReg)
 
     if (!blocks) {


### PR DESCRIPTION
The library cannot parse userscripts in which line wrapping is implemented using `\r\n`.
Adding of optional character `\r` into regex is solved this problem.